### PR TITLE
Static order of Biotype plot

### DIFF
--- a/multiqc_ngi/modules/featureCounts_biotype/feature_counts_biotype.py
+++ b/multiqc_ngi/modules/featureCounts_biotype/feature_counts_biotype.py
@@ -48,7 +48,7 @@ class MultiqcModule(BaseMultiqcModule):
 
         # Assignment bar plot
         # Only one section, so add to the intro
-        self.intro += self.featureCounts_biotypes_chart()
+        self.intro +=self.featureCounts_biotypes_chart()
 
 
     def parse_featurecounts_report (self, f):
@@ -102,14 +102,14 @@ class MultiqcModule(BaseMultiqcModule):
         """ Make the featureCounts assignment rates plot """
         #Order keys the same everytime
         keys = OrderedDict()
-        fixedorder = ['protein_coding', 'antisense', 'misc_RNA', 'pseudogene', 'processed_transcript', 
+        fixedorder = ['protein_coding','rRNA','miRNA', 'antisense', 'misc_RNA', 'pseudogene', 'processed_transcript', 
                 'processed_transcript', 'processed_pseudogene', 'sense_intronic', 'sense_overlapping',
-                'lincRNA', 'rRNA', 'snoRNA', 'miRNA', 'snRNA']
+                'lincRNA', 'snoRNA', 'snRNA']
         for d in self.featurecounts_biotype_data.values():
             for j in fixedorder:
                 if j in d and j not in keys.keys():
                     keys[j] = {'name': j.replace('_', ' ') }
-            # Order remianing keys by count in first dataset
+            # Order remaining keys by count in first dataset
             for k in sorted(d, key=d.get, reverse=True):
                 if k == 'percent_rRNA':
                     continue
@@ -123,4 +123,4 @@ class MultiqcModule(BaseMultiqcModule):
             'ylab': '# Reads',
             'cpswitch_counts_label': 'Number of Reads'
         }
-        
+        return plots.bargraph.plot(self.featurecounts_biotype_data, keys, pconfig) 

--- a/multiqc_ngi/modules/featureCounts_biotype/feature_counts_biotype.py
+++ b/multiqc_ngi/modules/featureCounts_biotype/feature_counts_biotype.py
@@ -100,61 +100,22 @@ class MultiqcModule(BaseMultiqcModule):
 
     def featureCounts_biotypes_chart (self):
         """ Make the featureCounts assignment rates plot """
-        
-        # Order keys by count in first dataset
+        #Order keys the same everytime
         keys = OrderedDict()
+        fixedorder = ['protein_coding', 'antisense', 'misc_RNA', 'pseudogene', 'processed_transcript', 
+                'processed_transcript', 'processed_pseudogene', 'sense_intronic', 'sense_overlapping',
+                'lincRNA', 'rRNA', 'snoRNA', 'miRNA', 'snRNA']
         for d in self.featurecounts_biotype_data.values():
-            for k in sorted(d):
-                print (k)
+            for j in fixedorder:
+                if j in d and j not in keys.keys():
+                    keys[j] = {'name': j.replace('_', ' ') }
+            # Order remianing keys by count in first dataset
+            for k in sorted(d, key=d.get, reverse=True):
                 if k == 'percent_rRNA':
                     continue
                 keys[k] = {'name': k.replace('_', ' ') }
             break
-        keys['protein_coding'] = {
-        'name': 'protein coding'
-        }
-        keys['antisense'] = {
-        'name': 'anti sense'
-        }
-        keys['misc_RNA'] = {
-        'name': 'misc RNA'
-        }
-        keys['lincRNA'] = {
-        'name': 'lincRNA'
-        }
-        keys['pseudogene'] = {
-        'name': 'pseudogene'
-        }
-        keys['processed_transcript'] = {
-        'name': 'processed transcript'
-        }
-        keys['processed_pseudogene'] = {
-        'name': 'processed pseudogene'
-        }
-        keys['sense_intronic'] = {
-        'name': 'sense_intronic'
-        }
-        keys['sense_overlapping'] = {
-        'name': 'sense overlapping'
-        }
-        keys['rRNA'] = {
-        'name': 'rRNA'
-        }
-        keys['snoRNA'] = {
-        'name': 'snoRNA'
-        }
-        keys['miRNA'] = {
-        'name': 'miRNA'
-        }
-        keys['snRNA'] = {
-        'name': 'snRNA'
-        }
-        keys['Mt_tRNA'] = {
-        'name': 'Mt_tRNA'
-        }
-        keys['Mt_rRNA'] = {
-        'name': 'Mt_rRNA'
-        }
+      
         # Config for the plot
         pconfig = {
             'id': 'featureCounts_biotype_plot',

--- a/multiqc_ngi/modules/featureCounts_biotype/feature_counts_biotype.py
+++ b/multiqc_ngi/modules/featureCounts_biotype/feature_counts_biotype.py
@@ -104,12 +104,57 @@ class MultiqcModule(BaseMultiqcModule):
         # Order keys by count in first dataset
         keys = OrderedDict()
         for d in self.featurecounts_biotype_data.values():
-            for k in sorted(d, key=d.get, reverse=True):
+            for k in sorted(d):
+                print (k)
                 if k == 'percent_rRNA':
                     continue
                 keys[k] = {'name': k.replace('_', ' ') }
             break
-        
+        keys['protein_coding'] = {
+        'name': 'protein coding'
+        }
+        keys['antisense'] = {
+        'name': 'anti sense'
+        }
+        keys['misc_RNA'] = {
+        'name': 'misc RNA'
+        }
+        keys['lincRNA'] = {
+        'name': 'lincRNA'
+        }
+        keys['pseudogene'] = {
+        'name': 'pseudogene'
+        }
+        keys['processed_transcript'] = {
+        'name': 'processed transcript'
+        }
+        keys['processed_pseudogene'] = {
+        'name': 'processed pseudogene'
+        }
+        keys['sense_intronic'] = {
+        'name': 'sense_intronic'
+        }
+        keys['sense_overlapping'] = {
+        'name': 'sense overlapping'
+        }
+        keys['rRNA'] = {
+        'name': 'rRNA'
+        }
+        keys['snoRNA'] = {
+        'name': 'snoRNA'
+        }
+        keys['miRNA'] = {
+        'name': 'miRNA'
+        }
+        keys['snRNA'] = {
+        'name': 'snRNA'
+        }
+        keys['Mt_tRNA'] = {
+        'name': 'Mt_tRNA'
+        }
+        keys['Mt_rRNA'] = {
+        'name': 'Mt_rRNA'
+        }
         # Config for the plot
         pconfig = {
             'id': 'featureCounts_biotype_plot',
@@ -118,4 +163,3 @@ class MultiqcModule(BaseMultiqcModule):
             'cpswitch_counts_label': 'Number of Reads'
         }
         
-        return plots.bargraph.plot(self.featurecounts_biotype_data, keys, pconfig)


### PR DESCRIPTION
Now the order will be static for the species that should be most abundant and interesting in a majority of projects.
These are defined in the `fixedorder` list, just change this to change the order. 
Keys not in this list are defined by abundance as previously.